### PR TITLE
Notify when microphone permission denied

### DIFF
--- a/background.js
+++ b/background.js
@@ -231,6 +231,19 @@ class BackgroundController {
           sendResponse({ success: true });
           break;
 
+        case 'MIC_PERMISSION_DENIED':
+          this.isCapturing = false;
+          if (request.tabId) {
+            this.captureState.set(request.tabId, false);
+            this.activeStreams.delete(request.tabId);
+            this.sendMessageToTab(request.tabId, {
+              type: 'MIC_PERMISSION_DENIED',
+              error: request.error
+            });
+          }
+          sendResponse({ success: true });
+          break;
+
         case 'NEW_SUBTITLE':
           if (request.tabId) {
             this.sendMessageToTab(request.tabId, {

--- a/content.js
+++ b/content.js
@@ -583,6 +583,12 @@ class SubtitleOverlay {
           console.error('Transcription error:', request.error);
           this.showNotification(`Transcription error: ${request.error}`, 'warning');
           break;
+
+        case 'MIC_PERMISSION_DENIED':
+          this.isActive = false;
+          console.error('Microphone permission denied');
+          this.showNotification('Please allow microphone access to use captions.', 'error');
+          break;
       }
       
       sendResponse({ success: true });

--- a/offscreen.js
+++ b/offscreen.js
@@ -160,8 +160,20 @@ class OffscreenAudioProcessor {
     // Handle recognition errors
     this.recognition.onerror = (event) => {
       console.error('Speech recognition error:', event.error);
-      
-      if (event.error === 'no-speech' && this.isCapturing) {
+
+      if (event.error === 'not-allowed') {
+        // User denied microphone permissions
+        chrome.runtime.sendMessage({
+          type: 'MIC_PERMISSION_DENIED',
+          tabId: this.currentTabId,
+          error: 'Microphone access was denied'
+        }).catch(err => {
+          console.error('Failed to send mic permission error:', err);
+        });
+
+        // Stop further recognition attempts
+        this.stopRecognition();
+      } else if (event.error === 'no-speech' && this.isCapturing) {
         // Only restart for recoverable errors
         this.scheduleRestart();
       } else if (event.error === 'audio-capture') {


### PR DESCRIPTION
## Summary
- send a `MIC_PERMISSION_DENIED` message when Web Speech API reports `not-allowed`
- relay the message through the background script
- show notification in content script to tell the user to enable microphone access
- stop recognition when permission is denied

## Testing
- `npm run build`

------
